### PR TITLE
[Feature] remove queue rewards for cvx staking

### DIFF
--- a/contracts/contracts/Booster.sol
+++ b/contracts/contracts/Booster.sol
@@ -550,7 +550,6 @@ contract Booster{
 
             //send stakers's share of crv to reward contract
             IERC20(crv).safeTransfer(stakerRewards, _stakerIncentive);
-            IRewards(stakerRewards).queueNewRewards(_stakerIncentive);
         }
     }
 


### PR DESCRIPTION
- Remove queue rewards for CvxStaking on the Booster as the `staker` is now CvxStakingProxy

related to this aura PR: 