### PR TITLE
feat: migrate CRV

### DIFF
--- a/contracts/contracts/Interfaces.sol
+++ b/contracts/contracts/Interfaces.sol
@@ -64,6 +64,7 @@ interface IStaker{
     function operator() external view returns (address);
     function execute(address _to, uint256 _value, bytes calldata _data) external returns (bool, bytes memory);
     function setVote(bytes32 hash, bool valid) external;
+    function migrate(address to) external;
 }
 
 interface IRewards{

--- a/contracts/contracts/VoterProxy.sol
+++ b/contracts/contracts/VoterProxy.sol
@@ -238,10 +238,17 @@ contract CurveVoterProxy {
      * @notice  Withdraw all CRV from Curve's voting escrow contract
      * @dev     Only callable by CrvDepositor and can only withdraw if lock has expired
      */
-    function release() external returns(bool){
+    function release() public returns(bool){
         require(msg.sender == depositor, "!auth");
         ICurveVoteEscrow(escrow).withdraw();
         return true;
+    }
+
+    function migrate(address to) external {
+        require(msg.sender == depositor, "!auth");
+        require(release(), "!release");
+        uint256 balance = IERC20(crv).balanceOf(address(this));
+        IERC20(crv).safeTransfer(to, balance);
     }
 
     /**


### PR DESCRIPTION
- Cool down period for CrvDepositor
   - No new locks
   - No increase time 
- dao can migrate CRV
  - dao can release locked CRV and migrate to a new contract
  - dao can only call this once cool down period has be set. Will still have to wait for the lock to expire after cool down has been set.


Tests in PR: https://github.com/aurafinance/aura-contracts/pull/20