### PR TITLE
feat: reward pool queue idle

### DIFF
--- a/contracts/contracts/BaseRewardPool.sol
+++ b/contracts/contracts/BaseRewardPool.sol
@@ -316,6 +316,13 @@ contract BaseRewardPool {
         queuedRewards = queuedRewards.add(_amount);
     }
 
+    function processIdleRewards() external {
+        if (block.timestamp >= periodFinish) {
+            notifyRewardAmount(queuedRewards);
+            queuedRewards = 0;
+        }
+    }
+
     /**
      * @dev Called by the booster to allocate new Crv rewards to this pool
      *      Curve is queued for rewards and the distribution only begins once the new rewards are sufficiently

--- a/contracts/contracts/BaseRewardPool.sol
+++ b/contracts/contracts/BaseRewardPool.sol
@@ -316,8 +316,12 @@ contract BaseRewardPool {
         queuedRewards = queuedRewards.add(_amount);
     }
 
+    /**
+     * @dev Processes queued rewards in isolation, providing the period has finished.
+     *      This allows a cheaper way to trigger rewards on low value pools.
+     */
     function processIdleRewards() external {
-        if (block.timestamp >= periodFinish) {
+        if (block.timestamp >= periodFinish && queuedRewards > 0) {
             notifyRewardAmount(queuedRewards);
             queuedRewards = 0;
         }


### PR DESCRIPTION
Processes queued rewards in isolation, providing the period has finished. This allows a cheaper way to trigger rewards on low value pools. As advised by C2tp.